### PR TITLE
Add user 'wiki', in order to create wiki pages with login user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,9 @@ VOLUME /wiki
 
 WORKDIR /wiki
 
+RUN useradd wiki
+
+USER wiki
+
 ENTRYPOINT ["gollum"]
 


### PR DESCRIPTION
When I use docker image `gollumorg/gollum:latest` , the wiki pages are created with `root`. This is inconvenient.

By adding user 'wiki', pages are created with login user.